### PR TITLE
Prefill Fix

### DIFF
--- a/_source/client/templates/components/forms/input.coffee
+++ b/_source/client/templates/components/forms/input.coffee
@@ -27,6 +27,15 @@ class Apollos.Forms.Input extends Apollos.Component
 
   ]
 
+
+  onRendered: ->
+
+    self = @
+
+    if self.data().preFill
+      self.value.set self.data().preFill
+
+
   focused: (event) ->
 
     self = @

--- a/_source/client/templates/components/forms/input.coffee
+++ b/_source/client/templates/components/forms/input.coffee
@@ -32,7 +32,7 @@ class Apollos.Forms.Input extends Apollos.Component
 
     self = @
 
-    if self.data().preFill
+    if self.data()?.preFill
       self.value.set self.data().preFill
 
 


### PR DESCRIPTION
This will sync the Input Component's value with the `preFill` param passed in. This is helpful when validating a form that has been re-rendered.