### PR TITLE
Observe each change once across multiple server instances

### DIFF
--- a/_source/lib/collections/_helpers.coffee
+++ b/_source/lib/collections/_helpers.coffee
@@ -7,6 +7,9 @@ Apollos.generateSchema = (name, schema) ->
     schema = name
     name = false
 
+  schema.observationHash or=
+    type: Number
+    optional: true
 
   schema.createdDate or=
     type: Date

--- a/_source/lib/routes/server/api.coffee
+++ b/_source/lib/routes/server/api.coffee
@@ -22,8 +22,6 @@ authenticatePlatform = (collection) ->
   sentToken = @.requestHeaders[Apollos.api.tokenName]
 
   for name, details of Apollos.api.platforms
-    console.log "Testing request against registered platform:", details
-
     token = details.token
     collections = details.collections
 
@@ -76,12 +74,9 @@ deleteResource = (handlerFunc, platform) ->
 upsertResource = (data, handlerFunc, platform) ->
 
   @.setContentType _jsonContentType
-  console.log "upserting resource:"
   resource = parseRequestData data, @.requestHeaders["content-type"]
-  console.log resource
   resource or= {}
   resource.Id = Number @.params.id
-  console.log "calling handler func"
   handlerFunc resource, platform
   return
 

--- a/_source/server/lib/_entityHelpers.coffee
+++ b/_source/server/lib/_entityHelpers.coffee
@@ -32,9 +32,7 @@ Apollos.documentHelpers =
   ###
   update: (singular, plural, doc, platform) ->
 
-    console.log "Document helper update method"
     doc = Apollos[singular].translate doc, platform
-    console.log "Translated doc as", doc
 
     if not doc
       return
@@ -75,14 +73,12 @@ Apollos.documentHelpers =
       existing = matches.fetch()[0]
       mongoId = existing._id
 
-      console.log "UPDATING:", doc
       Apollos[plural].update
         _id: mongoId
       ,
         $set: doc
 
     else
-      console.log "INSERTING:", doc
       mongoId = Apollos[plural].insert doc
 
     return mongoId

--- a/_source/server/lib/observe.coffee
+++ b/_source/server/lib/observe.coffee
@@ -1,34 +1,86 @@
+changeWasAlreadyHandled = (doc, collection) ->
+
+  if not doc.observationHash
+    return false
+
+  hash = hashObject doc
+
+  if doc.observationHash is hash
+    return true
+
+  Apollos[collection].update doc._id, $set: observationHash: hash
+  doc.observationHash = hash
+  return false
+
+hashObject = (obj) ->
+
+  json = JSON.stringify obj
+  hash = 0
+  i = 0
+  len = json.length
+
+  if len is 0
+    return hash
+
+  while i < len
+    chr = json.charCodeAt(i)
+    hash  = ((hash << 5) - hash) + chr
+    hash |= 0
+    i++
+
+  return hash
 
 Apollos.observe = (collection) ->
 
   initializing = true
 
-  Apollos[collection].find().observe
+  Apollos[collection].find({},
+    fields:
+      observationHash: 0
+      createdDate: 0
+      updatedDate: 0
+      updatedBy: 0
+  ).observeChanges
 
-    added: (doc) ->
+    added: (id) ->
 
       if initializing
         return
 
+      doc = Apollos[collection].findOne id
+      if changeWasAlreadyHandled doc, collection
+        Apollos.debug "#{collection} #{id} add already handled"
+        return
+
+      Apollos.debug "Handling add in #{collection} #{id}"
       Apollos[collection].added or= {}
+      platformAddedBy = doc.updatedBy?.toUpperCase()
 
       for platform, handle of Apollos[collection].added
-        handle doc
+        if platformAddedBy and (platformAddedBy isnt platform.toUpperCase())
+          handle doc
 
+    changed: (id) ->
 
-    changed: (newDoc, oldDoc) ->
+      doc = Apollos[collection].findOne id
+      if changeWasAlreadyHandled doc, collection
+        Apollos.debug "#{collection} #{id} change already handled"
+        return
 
+      Apollos.debug "Handling change in #{collection} #{id}"
       Apollos[collection].changed or= {}
+      platformChangedBy = doc.updatedBy?.toUpperCase()
 
       for platform, handle of Apollos[collection].changed
-        handle newDoc, oldDoc
+        if platformChangedBy and (platformChangedBy isnt platform.toUpperCase())
+          handle doc
 
-    removed: (doc) ->
+    removed: (id) ->
 
       Apollos[collection].deleted or= {}
 
       for platform, handle of Apollos[collection].deleted
-        handle doc
+        handle id
 
 
   initializing = false


### PR DESCRIPTION
*** Pull request in rock and core

1. Use a hash of the doc (observationHash) to know if another server instance already handled the change
2. Check at a more abstract level if the updatedBy platform matches so each collection for each platform doesn't need the same code to do the check
3. Remove a lot of console logging.