### PR TITLE
Sync Scheduled Transactions

### DIFF
--- a/_source/lib/routes/server/api.coffee
+++ b/_source/lib/routes/server/api.coffee
@@ -17,7 +17,7 @@ _unexpectedError = 500
   @param context should be the HTTP.methods handler function
 
 ###
-authenticatePlatform = (collection) ->
+_authenticatePlatform = (collection) ->
 
   sentToken = @.requestHeaders[Apollos.api.tokenName]
 
@@ -39,18 +39,18 @@ authenticatePlatform = (collection) ->
 
 ###
 
-  deleteResource
+  _deleteResource
 
   @example authenticates and then calls the delete handler
 
-    return deleteResource.call @, Apollos.person.delete, platform
+    return _deleteResource.call @, Apollos.person.delete, platform
 
   @param context should be the HTTP.methods handler function
   @param handlerFunc is the function that will delete the resource
   @param platform is the source of the request to delete the resource
 
 ###
-deleteResource = (handlerFunc, platform) ->
+_deleteResource = (handlerFunc, platform) ->
 
   @.setContentType _jsonContentType
   id = Number @.params.id
@@ -59,11 +59,11 @@ deleteResource = (handlerFunc, platform) ->
 
 ###
 
-  upsertResource
+  _upsertResource
 
   @example authenticates and then calls the upsert handler
 
-    return upsertResource.call @, data, Apollos.person.update, platform
+    return _upsertResource.call @, data, Apollos.person.update, platform
 
   @param context should be the HTTP.methods handler function
   @param data is the javascript object with the request data
@@ -71,7 +71,7 @@ deleteResource = (handlerFunc, platform) ->
   @param platform is the source of the request to upsert the resource
 
 ###
-upsertResource = (data, handlerFunc, platform) ->
+_upsertResource = (data, handlerFunc, platform) ->
 
   @.setContentType _jsonContentType
   resource = parseRequestData data, @.requestHeaders["content-type"]
@@ -82,19 +82,19 @@ upsertResource = (data, handlerFunc, platform) ->
 
 ###
 
-  createEndpoint
+  _createEndpoint
 
   @example creartes a standard API endpoint at the given URL for the given
     entity
 
-    createEndpoint "api/v1/people/", "person"
+    _createEndpoint "api/v1/people/", "person"
 
   @param url [String] the endpoint for the API to operate at
   @param entityType [String] is the name of the Apollos type that this endpoint
     is associated with
 
 ###
-createEndpoint = (collection, singular, nameForUrl, options) ->
+_createEndpoint = (collection, singular, nameForUrl, options) ->
   options or= {}
   url = "#{Apollos.api.base}/#{nameForUrl}/:id"
 
@@ -104,7 +104,7 @@ createEndpoint = (collection, singular, nameForUrl, options) ->
     post: (data) ->
       try
         Apollos.debug "Got POST #{url} id=#{@.params.id}"
-        platform = authenticatePlatform.call @, collection
+        platform = _authenticatePlatform.call @, collection
 
         if platform
           Apollos.debug "POST authenticated from #{platform.name}"
@@ -113,11 +113,12 @@ createEndpoint = (collection, singular, nameForUrl, options) ->
           Apollos.debug "Dropping request because of unknown platform"
           return
 
-        handler = Apollos[singular].update
         if options.subDocName
-          handler = handler[options.subDocName]
+          handler = Apollos[singular][options.subDocName].update
+        else
+          handler = Apollos[singular].update
 
-        return upsertResource.call @, data, handler, platform.name
+        return _upsertResource.call @, data, handler, platform.name
 
       catch error
         @.setStatusCode _unexpectedError
@@ -128,17 +129,18 @@ createEndpoint = (collection, singular, nameForUrl, options) ->
     delete: (data) ->
       try
         Apollos.debug "Got DELETE for #{url} id=#{@.params.id}"
-        platform = authenticatePlatform.call @, collection
+        platform = _authenticatePlatform.call @, collection
 
         if not platform
           Apollos.debug "Dropping request because of unknown platform"
           return
 
-        handler = Apollos[singular].update
         if options.subDocName
-          handler = handler[options.subDocName]
+          handler = Apollos[singular][options.subDocName].delete
+        else
+          handler = Apollos[singular].delete
 
-        return deleteResource.call @, handler, platform.name
+        return _deleteResource.call @, handler, platform.name
 
       catch error
         @.setStatusCode _unexpectedError
@@ -152,7 +154,6 @@ createEndpoint = (collection, singular, nameForUrl, options) ->
 # Register a collection's endpoint
 Apollos.api.addEndpoint = (collection, singular, options) ->
 
-  obj = {}
   options or= {}
 
   options.nameForUrl or= collection
@@ -160,7 +161,7 @@ Apollos.api.addEndpoint = (collection, singular, options) ->
     Apollos.debug "There is already an endpoint for #{nameForUrl}"
     return
 
-  url = createEndpoint collection, singular, options.nameForUrl, options
+  url = _createEndpoint collection, singular, options.nameForUrl, options
   Apollos.api.endpoints[options.nameForUrl] = url: url
 
   return

--- a/_source/lib/routes/server/main.coffee
+++ b/_source/lib/routes/server/main.coffee
@@ -1,5 +1,6 @@
 # Register core collections
 Apollos.api.addEndpoint "users", "user"
+# TODO Make aliases a subdoc of people
 Apollos.api.addEndpoint "people", "person"
 Apollos.api.addEndpoint "campuses", "campus"
 Apollos.api.addEndpoint "groups", "group"

--- a/_source/server/lib/_entityHelpers.coffee
+++ b/_source/server/lib/_entityHelpers.coffee
@@ -62,6 +62,8 @@ Apollos.documentHelpers =
 
       ids.pop()
 
+
+      # can we make this async?
       Apollos[plural].remove
         _id:
           $in: ids
@@ -72,14 +74,17 @@ Apollos.documentHelpers =
       existing = matches.fetch()[0]
       mongoId = existing._id
 
+      # can we make this async?
       Apollos[plural].update
         _id: mongoId
       ,
         $set: doc
 
     else
+      # can we make this async?
       mongoId = Apollos[plural].insert doc
 
+    # what use case do we have where we need the id returned?
     return mongoId
 
 
@@ -119,6 +124,7 @@ Apollos.documentHelpers =
     else
       doc.updatedBy = Apollos.name
 
+    # Can we async this?
     # We have to update this first so the collection hooks know what to do
     Apollos[plural].update
       _id: doc._id
@@ -126,4 +132,5 @@ Apollos.documentHelpers =
       $set:
         "updatedBy": doc.updatedBy
 
+    # Can we async this?
     Apollos[plural].remove doc._id

--- a/_source/server/lib/_entityHelpers.coffee
+++ b/_source/server/lib/_entityHelpers.coffee
@@ -1,7 +1,7 @@
 Apollos.documentHelpers =
 
 
-  translate: (singular, data, platform) ->
+  translate: (singular, data, platform, subName) ->
 
     if not platform
       Apollos.debug "must specify platform to translate to"
@@ -13,8 +13,7 @@ Apollos.documentHelpers =
       return
 
     # translate
-    return Apollos[singular]._dictionary[platform] data
-
+    return Apollos[singular]._dictionary[platform] data, subName
 
   ###
 
@@ -30,9 +29,9 @@ Apollos.documentHelpers =
     @param platform [String] platform to be updated from
 
   ###
-  update: (singular, plural, doc, platform) ->
+  update: (singular, plural, doc, platform, subName) ->
 
-    doc = Apollos[singular].translate doc, platform
+    doc = Apollos[singular].translate doc, platform, subName
 
     if not doc
       return
@@ -98,7 +97,7 @@ Apollos.documentHelpers =
     @param platform [String] platform initiating the delete
 
   ###
-  delete: (singular, plural, identifier, platform) ->
+  delete: (singular, plural, identifier, platform, subName) ->
 
     if typeof identifier is "number"
       singularIdKeyValue = {}

--- a/_source/server/lib/observe.coffee
+++ b/_source/server/lib/observe.coffee
@@ -1,3 +1,5 @@
+collectionsObserved = {}
+
 changeWasAlreadyHandled = (doc, collection) ->
 
   if not doc.observationHash
@@ -30,8 +32,12 @@ hashObject = (obj) ->
 
   return hash
 
-Apollos.observe = (collection) ->
+startObserveIfNeeded = (collection) ->
 
+  if collectionsObserved[collection]
+    return
+
+  collectionsObserved[collection] = true
   initializing = true
 
   Apollos[collection].find({},
@@ -85,7 +91,7 @@ Apollos.observe = (collection) ->
 
   initializing = false
 
-
+Apollos.observe = {}
 
 Apollos.observe.remove = (doc, platform, methods) ->
 
@@ -103,7 +109,6 @@ Apollos.observe.remove = (doc, platform, methods) ->
   for method in methods
     delete Apollos[doc][method]
 
-
 Apollos.observe.add = (doc, platform, methods) ->
 
   if not Apollos[doc]
@@ -114,7 +119,6 @@ Apollos.observe.add = (doc, platform, methods) ->
     Apollos.debug "Must specify platform"
     return
 
-
   for method, handle of methods
 
     Apollos[doc][method] or= {}
@@ -122,7 +126,6 @@ Apollos.observe.add = (doc, platform, methods) ->
     if Apollos[doc][method][platform]
       Apollos.debug "The #{method} observe handler for #{doc} from #{platform} has already been set"
       return
+
     Apollos[doc][method][platform] = handle
-
-
-  return
+    startObserveIfNeeded doc

--- a/_source/server/lib/observe.coffee
+++ b/_source/server/lib/observe.coffee
@@ -10,10 +10,13 @@ changeWasAlreadyHandled = (doc, collection) ->
   if doc.observationHash is hash
     return true
 
+  # can we make this async?
   Apollos[collection].update doc._id, $set: observationHash: hash
   doc.observationHash = hash
   return false
 
+
+# @benwiley can we just use Random.id()?
 hashObject = (obj) ->
 
   json = JSON.stringify obj
@@ -93,6 +96,8 @@ startObserveIfNeeded = (collection) ->
 
 Apollos.observe = {}
 
+
+# this method should probably also remove the handler?
 Apollos.observe.remove = (doc, platform, methods) ->
 
   if not Apollos[doc]
@@ -125,6 +130,7 @@ Apollos.observe.add = (doc, platform, methods) ->
 
     if Apollos[doc][method][platform]
       Apollos.debug "The #{method} observe handler for #{doc} from #{platform} has already been set"
+      # make this a continue?
       return
 
     Apollos[doc][method][platform] = handle

--- a/_source/server/lib/person.coffee
+++ b/_source/server/lib/person.coffee
@@ -47,12 +47,3 @@ Apollos.person.update = (person, platform) ->
 ###
 Apollos.person.delete = (person, platform) ->
   Apollos.documentHelpers.delete "person", "people", person, platform
-
-###
-
-  Update bindings
-
-###
-Meteor.startup ->
-
-  Apollos.observe "people"

--- a/_source/server/lib/user.coffee
+++ b/_source/server/lib/user.coffee
@@ -116,8 +116,3 @@ Apollos.user.update = (user, platform) ->
       $set: user
 
     return usr._id
-
-
-Meteor.startup ->
-
-  Apollos.observe "users"


### PR DESCRIPTION
*** Pull request in core, give, and rock

1.) New method to sync sub-documents such as scheduled transactions' details
2.) Start observing a collection automatically if needed when a request is made to hook into the observe